### PR TITLE
Issue with sending an empty string as the Page title

### DIFF
--- a/lib/survey_gizmo/api/page.rb
+++ b/lib/survey_gizmo/api/page.rb
@@ -23,7 +23,7 @@ module SurveyGizmo; module API
     # survey gizmo sends a hash back for :title
     # @private
     def title_with_multilingual=(val)
-      self.title_without_multilingual = val.is_a?(Hash) ? val : val['English']
+      self.title_without_multilingual = val.is_a?(Hash) ? val : { "English" => val }
     end
 
     alias_method_chain :title=, :multilingual


### PR DESCRIPTION
An error will occur when setting Page title to an empty string, as survey gizmo will send back and empty array rather than a hash
